### PR TITLE
feat: 实现学生端登录与首次校验页面

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "lesi-edu-stu",
       "version": "0.1.0",
       "dependencies": {
-        "vue": "^3.5.13"
+        "vue": "^3.5.13",
+        "vue-router": "^4.6.4"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.18",
@@ -1299,6 +1300,12 @@
         "he": "^1.2.0"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/language-core": {
       "version": "2.2.12",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
@@ -2134,6 +2141,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/vue-tsc": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "check": "vue-tsc --noEmit"
   },
   "dependencies": {
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",
@@ -21,4 +22,3 @@
     "vue-tsc": "^2.2.0"
   }
 }
-

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,26 +1,44 @@
+<script setup lang="ts">
+import { useRoute, useRouter } from "vue-router";
+import { useAuthStore } from "./stores/auth";
+
+const route = useRoute();
+const router = useRouter();
+const auth = useAuthStore();
+
+const onLogout = () => {
+  auth.logout();
+  router.replace("/login");
+};
+</script>
+
 <template>
-  <main class="mx-auto flex min-h-screen max-w-5xl flex-col justify-center px-6 py-10">
-    <section class="overflow-hidden rounded-3xl border border-slate-200 bg-white/90 shadow-xl">
-      <div class="bg-brand-500 px-8 py-8 text-white">
-        <p class="text-sm uppercase tracking-[0.2em] text-white/70">LESI EDU</p>
-        <h1 class="mt-2 text-3xl font-bold">学生端前端已初始化</h1>
-        <p class="mt-3 text-white/90">用于学生成长导航、岗位匹配与就业服务。</p>
+  <main class="mx-auto flex min-h-screen max-w-5xl flex-col px-6 py-10">
+    <header class="mb-6 rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p class="text-xs uppercase tracking-[0.18em] text-slate-500">LESI EDU</p>
+          <h1 class="text-lg font-bold text-slate-900">学生端</h1>
+        </div>
+
+        <nav class="flex items-center gap-2">
+          <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/reports">报告</RouterLink>
+          <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/tasks">任务</RouterLink>
+          <button
+            v-if="auth.isLoggedIn.value"
+            class="rounded-lg bg-slate-900 px-3 py-1.5 text-sm text-white"
+            @click="onLogout"
+          >
+            退出
+          </button>
+        </nav>
       </div>
-      <div class="grid gap-4 px-8 py-8 md:grid-cols-3">
-        <article class="rounded-2xl border border-slate-200 p-4">
-          <h2 class="text-sm font-semibold text-slate-900">Vue 3</h2>
-          <p class="mt-2 text-sm text-slate-600">组合式 API 与类型化组件开发。</p>
-        </article>
-        <article class="rounded-2xl border border-slate-200 p-4">
-          <h2 class="text-sm font-semibold text-slate-900">Vite</h2>
-          <p class="mt-2 text-sm text-slate-600">快速冷启动与构建。</p>
-        </article>
-        <article class="rounded-2xl border border-slate-200 p-4">
-          <h2 class="text-sm font-semibold text-slate-900">Tailwind CSS v4</h2>
-          <p class="mt-2 text-sm text-slate-600">CSS-first 设计令牌与原子化样式体系。</p>
-        </article>
-      </div>
-    </section>
+
+      <p v-if="route.path === '/first-verify'" class="mt-3 rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-700">
+        首次校验完成前，报告页与任务页将被拦截。
+      </p>
+    </header>
+
+    <RouterView />
   </main>
 </template>
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { createApp } from "vue";
 import App from "./App.vue";
+import router from "./router";
 import "./style.css";
 
-createApp(App).mount("#app");
-
+createApp(App).use(router).mount("#app");

--- a/src/pages/FirstVerifyPage.vue
+++ b/src/pages/FirstVerifyPage.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { reactive, ref } from "vue";
+import { useRouter } from "vue-router";
+import { ApiError } from "../services/http";
+import { useAuthStore } from "../stores/auth";
+
+const router = useRouter();
+const auth = useAuthStore();
+
+const form = reactive({
+  name: "",
+  credentialNo: "",
+  schoolName: "",
+  majorName: ""
+});
+
+const loading = ref(false);
+const success = ref(false);
+const errorText = ref("");
+
+const onSubmit = async () => {
+  loading.value = true;
+  errorText.value = "";
+
+  try {
+    await auth.firstLoginVerify({ ...form });
+    success.value = true;
+    setTimeout(() => {
+      router.replace("/reports");
+    }, 800);
+  } catch (error) {
+    if (error instanceof ApiError) {
+      errorText.value = error.message;
+    } else {
+      errorText.value = "校验失败，请稍后重试";
+    }
+  } finally {
+    loading.value = false;
+  }
+};
+</script>
+
+<template>
+  <section class="mx-auto max-w-lg rounded-2xl border border-slate-200 bg-white p-6 shadow">
+    <h1 class="text-xl font-bold text-slate-900">首次登录校验</h1>
+    <p class="mt-2 text-sm text-slate-600">请按招生档案填写以下信息完成身份校验。</p>
+
+    <form class="mt-6 grid gap-4 md:grid-cols-2" @submit.prevent="onSubmit">
+      <label class="block text-sm md:col-span-1">
+        <span class="mb-1 block text-slate-700">姓名</span>
+        <input v-model="form.name" class="w-full rounded-lg border border-slate-300 px-3 py-2" required />
+      </label>
+      <label class="block text-sm md:col-span-1">
+        <span class="mb-1 block text-slate-700">证件号</span>
+        <input v-model="form.credentialNo" class="w-full rounded-lg border border-slate-300 px-3 py-2" required />
+      </label>
+      <label class="block text-sm md:col-span-1">
+        <span class="mb-1 block text-slate-700">院校</span>
+        <input v-model="form.schoolName" class="w-full rounded-lg border border-slate-300 px-3 py-2" required />
+      </label>
+      <label class="block text-sm md:col-span-1">
+        <span class="mb-1 block text-slate-700">专业</span>
+        <input v-model="form.majorName" class="w-full rounded-lg border border-slate-300 px-3 py-2" required />
+      </label>
+
+      <p v-if="errorText" class="text-sm text-rose-600 md:col-span-2">{{ errorText }}</p>
+      <p v-if="success" class="text-sm text-emerald-600 md:col-span-2">校验成功，正在跳转...</p>
+
+      <button
+        type="submit"
+        class="md:col-span-2 rounded-lg bg-brand-500 px-3 py-2 text-white disabled:cursor-not-allowed disabled:opacity-60"
+        :disabled="loading"
+      >
+        {{ loading ? "提交中..." : "提交校验" }}
+      </button>
+    </form>
+  </section>
+</template>

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { reactive, ref } from "vue";
+import { useRouter } from "vue-router";
+import { ApiError } from "../services/http";
+import { useAuthStore } from "../stores/auth";
+
+const auth = useAuthStore();
+const router = useRouter();
+
+const form = reactive({
+  studentNo: "",
+  password: ""
+});
+
+const submitting = ref(false);
+const errorText = ref("");
+
+const onSubmit = async () => {
+  submitting.value = true;
+  errorText.value = "";
+
+  try {
+    await auth.login({ studentNo: form.studentNo, password: form.password });
+    await router.replace("/first-verify");
+  } catch (error) {
+    if (error instanceof ApiError) {
+      errorText.value = error.message;
+    } else {
+      errorText.value = "登录失败，请稍后重试";
+    }
+  } finally {
+    submitting.value = false;
+  }
+};
+</script>
+
+<template>
+  <section class="mx-auto max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow">
+    <h1 class="text-xl font-bold text-slate-900">学生登录</h1>
+    <p class="mt-2 text-sm text-slate-600">请输入学号和密码登录系统。</p>
+
+    <form class="mt-6 space-y-4" @submit.prevent="onSubmit">
+      <label class="block text-sm">
+        <span class="mb-1 block text-slate-700">学号</span>
+        <input v-model="form.studentNo" class="w-full rounded-lg border border-slate-300 px-3 py-2" required />
+      </label>
+      <label class="block text-sm">
+        <span class="mb-1 block text-slate-700">密码</span>
+        <input v-model="form.password" type="password" class="w-full rounded-lg border border-slate-300 px-3 py-2" required />
+      </label>
+
+      <p v-if="errorText" class="text-sm text-rose-600">{{ errorText }}</p>
+
+      <button
+        type="submit"
+        class="w-full rounded-lg bg-brand-500 px-3 py-2 text-white disabled:cursor-not-allowed disabled:opacity-60"
+        :disabled="submitting"
+      >
+        {{ submitting ? "登录中..." : "登录" }}
+      </button>
+    </form>
+  </section>
+</template>

--- a/src/pages/ReportsPage.vue
+++ b/src/pages/ReportsPage.vue
@@ -1,0 +1,6 @@
+<template>
+  <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow">
+    <h1 class="text-xl font-bold text-slate-900">我的报告</h1>
+    <p class="mt-2 text-sm text-slate-600">首次校验通过后可访问报告页面。</p>
+  </section>
+</template>

--- a/src/pages/TasksPage.vue
+++ b/src/pages/TasksPage.vue
@@ -1,0 +1,6 @@
+<template>
+  <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow">
+    <h1 class="text-xl font-bold text-slate-900">任务中心</h1>
+    <p class="mt-2 text-sm text-slate-600">首次校验通过后可访问任务页面。</p>
+  </section>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,41 @@
+import { createRouter, createWebHistory } from "vue-router";
+import FirstVerifyPage from "../pages/FirstVerifyPage.vue";
+import LoginPage from "../pages/LoginPage.vue";
+import ReportsPage from "../pages/ReportsPage.vue";
+import TasksPage from "../pages/TasksPage.vue";
+import { useAuthStore } from "../stores/auth";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: "/", redirect: "/login" },
+    { path: "/login", component: LoginPage },
+    { path: "/first-verify", component: FirstVerifyPage, meta: { requiresAuth: true } },
+    { path: "/reports", component: ReportsPage, meta: { requiresAuth: true, requiresVerified: true } },
+    { path: "/tasks", component: TasksPage, meta: { requiresAuth: true, requiresVerified: true } }
+  ]
+});
+
+router.beforeEach((to) => {
+  const auth = useAuthStore();
+
+  if (to.meta.requiresAuth && !auth.isLoggedIn.value) {
+    return "/login";
+  }
+
+  if (to.path === "/login" && auth.isLoggedIn.value) {
+    return auth.requiresFirstVerify.value ? "/first-verify" : "/reports";
+  }
+
+  if (to.meta.requiresVerified && auth.requiresFirstVerify.value) {
+    return "/first-verify";
+  }
+
+  if (to.path === "/first-verify" && auth.isLoggedIn.value && !auth.requiresFirstVerify.value) {
+    return "/reports";
+  }
+
+  return true;
+});
+
+export default router;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,20 @@
+import { requestJson } from "./http";
+import type { FirstLoginVerifyPayload, FirstLoginVerifyResponse, StudentLoginResponse } from "../types/auth";
+
+export const authApi = {
+  login(payload: { studentNo: string; password: string }) {
+    return requestJson<StudentLoginResponse>("/auth/student/login", {
+      method: "POST",
+      body: JSON.stringify(payload)
+    });
+  },
+  firstLoginVerify(token: string, payload: FirstLoginVerifyPayload) {
+    return requestJson<FirstLoginVerifyResponse>("/auth/student/first-login-verify", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(payload)
+    });
+  }
+};

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,0 +1,35 @@
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.trim() || "http://localhost:3000";
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly payload?: unknown
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+export async function requestJson<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(init.headers ?? {})
+    }
+  });
+
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : null;
+
+  if (!response.ok) {
+    throw new ApiError(
+      (payload as { message?: string } | null)?.message || `请求失败(${response.status})`,
+      response.status,
+      payload
+    );
+  }
+
+  return payload as T;
+}

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,0 +1,79 @@
+import { computed, reactive } from "vue";
+import { authApi } from "../services/auth";
+import type { FirstLoginVerifyPayload } from "../types/auth";
+
+interface AuthState {
+  token: string | null;
+  mustChangePassword: boolean;
+  firstLoginVerified: boolean;
+  studentNo: string | null;
+}
+
+const STORAGE_KEY = "lesi_stu_auth";
+
+const readInitialState = (): AuthState => {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return { token: null, mustChangePassword: false, firstLoginVerified: false, studentNo: null };
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as AuthState;
+    return {
+      token: parsed.token ?? null,
+      mustChangePassword: Boolean(parsed.mustChangePassword),
+      firstLoginVerified: Boolean(parsed.firstLoginVerified),
+      studentNo: parsed.studentNo ?? null
+    };
+  } catch {
+    return { token: null, mustChangePassword: false, firstLoginVerified: false, studentNo: null };
+  }
+};
+
+const state = reactive<AuthState>(readInitialState());
+
+const persist = () => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+};
+
+export const useAuthStore = () => {
+  const isLoggedIn = computed(() => !!state.token);
+  const requiresFirstVerify = computed(() => isLoggedIn.value && !state.firstLoginVerified);
+
+  const login = async (input: { studentNo: string; password: string }) => {
+    const result = await authApi.login(input);
+    state.token = result.token;
+    state.mustChangePassword = result.mustChangePassword;
+    state.firstLoginVerified = false;
+    state.studentNo = input.studentNo.trim();
+    persist();
+  };
+
+  const firstLoginVerify = async (payload: FirstLoginVerifyPayload) => {
+    if (!state.token) {
+      throw new Error("未登录");
+    }
+
+    const result = await authApi.firstLoginVerify(state.token, payload);
+    state.firstLoginVerified = result.verified;
+    persist();
+    return result;
+  };
+
+  const logout = () => {
+    state.token = null;
+    state.studentNo = null;
+    state.firstLoginVerified = false;
+    state.mustChangePassword = false;
+    persist();
+  };
+
+  return {
+    state,
+    isLoggedIn,
+    requiresFirstVerify,
+    login,
+    firstLoginVerify,
+    logout
+  };
+};

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,18 @@
+export interface StudentLoginResponse {
+  token: string;
+  tokenType: string;
+  expiresIn: number;
+  mustChangePassword: boolean;
+}
+
+export interface FirstLoginVerifyPayload {
+  name: string;
+  credentialNo: string;
+  schoolName: string;
+  majorName: string;
+}
+
+export interface FirstLoginVerifyResponse {
+  verified: boolean;
+  verifiedAt: string;
+}


### PR DESCRIPTION
Closes #2

## 变更内容
- 新增学生登录页与首次登录校验页
- 新增路由守卫：校验前访问 `/reports`、`/tasks` 自动拦截到 `/first-verify`
- 新增认证状态存储（token/校验状态）及退出登录
- 新增 API 服务层，失败提示透传后端 message

## 验证
- `npm run build` 通过
