### PR TITLE
feat: 实现学生端我的画像页面

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,6 +22,7 @@ const onLogout = () => {
         </div>
 
         <nav class="flex items-center gap-2">
+          <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/profile">画像</RouterLink>
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/reports">报告</RouterLink>
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/tasks">任务</RouterLink>
           <button

--- a/src/pages/ProfilePage.vue
+++ b/src/pages/ProfilePage.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { ApiError } from "../services/http";
+import { profileApi } from "../services/profile";
+import { useAuthStore } from "../stores/auth";
+import type { EnrollmentProfile } from "../types/profile";
+
+const auth = useAuthStore();
+const loading = ref(true);
+const errorText = ref("");
+const profile = ref<EnrollmentProfile | null>(null);
+
+const tags = computed(() => {
+  if (!profile.value) {
+    return [] as string[];
+  }
+
+  const source = profile.value;
+  return [
+    source.admissionYear ? `${source.admissionYear}级` : null,
+    source.majorName ? `专业：${source.majorName}` : null,
+    source.schoolName ? `院校：${source.schoolName}` : null,
+    source.score !== null ? `总分：${source.score}` : null
+  ].filter((item): item is string => !!item);
+});
+
+onMounted(async () => {
+  if (!auth.state.token) {
+    loading.value = false;
+    return;
+  }
+
+  try {
+    const result = await profileApi.getEnrollmentProfile(auth.state.token);
+    profile.value = result.profile;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      errorText.value = error.message;
+    } else {
+      errorText.value = "画像信息加载失败";
+    }
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow">
+    <h1 class="text-xl font-bold text-slate-900">我的画像</h1>
+    <p class="mt-2 text-sm text-slate-600">展示招生档案关键字段，仅供查看（只读）。</p>
+
+    <p v-if="loading" class="mt-6 text-sm text-slate-500">加载中...</p>
+    <p v-else-if="errorText" class="mt-6 text-sm text-rose-600">{{ errorText }}</p>
+
+    <template v-else>
+      <div class="mt-6 grid gap-3 md:grid-cols-2">
+        <article class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+          <p class="text-xs text-slate-500">总分</p>
+          <p class="mt-1 text-2xl font-bold text-slate-900">{{ profile?.score ?? "--" }}</p>
+        </article>
+        <article class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+          <p class="text-xs text-slate-500">科类/专业</p>
+          <p class="mt-1 text-lg font-semibold text-slate-900">{{ profile?.majorName ?? "--" }}</p>
+        </article>
+      </div>
+
+      <div class="mt-5 flex flex-wrap gap-2">
+        <span
+          v-for="tag in tags"
+          :key="tag"
+          class="rounded-full border border-brand-500/30 bg-brand-500/10 px-3 py-1 text-xs text-brand-700"
+        >
+          {{ tag }}
+        </span>
+      </div>
+
+      <dl class="mt-6 grid gap-3 md:grid-cols-2">
+        <div class="rounded-xl border border-slate-200 p-3">
+          <dt class="text-xs text-slate-500">学号</dt>
+          <dd class="mt-1 text-sm font-medium text-slate-900">{{ profile?.studentNo ?? "--" }}</dd>
+        </div>
+        <div class="rounded-xl border border-slate-200 p-3">
+          <dt class="text-xs text-slate-500">姓名</dt>
+          <dd class="mt-1 text-sm font-medium text-slate-900">{{ profile?.name ?? "--" }}</dd>
+        </div>
+        <div class="rounded-xl border border-slate-200 p-3">
+          <dt class="text-xs text-slate-500">院校</dt>
+          <dd class="mt-1 text-sm font-medium text-slate-900">{{ profile?.schoolName ?? "--" }}</dd>
+        </div>
+        <div class="rounded-xl border border-slate-200 p-3">
+          <dt class="text-xs text-slate-500">入学年份</dt>
+          <dd class="mt-1 text-sm font-medium text-slate-900">{{ profile?.admissionYear ?? "--" }}</dd>
+        </div>
+      </dl>
+    </template>
+  </section>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import FirstVerifyPage from "../pages/FirstVerifyPage.vue";
 import LoginPage from "../pages/LoginPage.vue";
 import ReportsPage from "../pages/ReportsPage.vue";
+import ProfilePage from "../pages/ProfilePage.vue";
 import TasksPage from "../pages/TasksPage.vue";
 import { useAuthStore } from "../stores/auth";
 
@@ -11,6 +12,7 @@ const router = createRouter({
     { path: "/", redirect: "/login" },
     { path: "/login", component: LoginPage },
     { path: "/first-verify", component: FirstVerifyPage, meta: { requiresAuth: true } },
+    { path: "/profile", component: ProfilePage, meta: { requiresAuth: true, requiresVerified: true } },
     { path: "/reports", component: ReportsPage, meta: { requiresAuth: true, requiresVerified: true } },
     { path: "/tasks", component: TasksPage, meta: { requiresAuth: true, requiresVerified: true } }
   ]

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -1,0 +1,12 @@
+import { requestJson } from "./http";
+import type { EnrollmentProfileResponse } from "../types/profile";
+
+export const profileApi = {
+  getEnrollmentProfile(token: string) {
+    return requestJson<EnrollmentProfileResponse>("/auth/student/enrollment-profile", {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+  }
+};

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,13 @@
+export interface EnrollmentProfile {
+  studentNo: string;
+  name: string | null;
+  schoolName: string | null;
+  majorName: string | null;
+  score: number | null;
+  admissionYear: number | null;
+}
+
+export interface EnrollmentProfileResponse {
+  status: "complete" | "missing";
+  profile: EnrollmentProfile | null;
+}


### PR DESCRIPTION
Closes #3

## 变更内容
- 新增 `我的画像` 页面（只读）
- 展示总分/院校/专业/学号/姓名/入学年份
- 增加标准化标签展示并与后端字段映射
- 新增 `/profile` 路由并接入顶部导航

## 验证
- `npm run build` 通过
