### PR TITLE
feat: 实现学生端测评答题与结果页

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -23,6 +23,7 @@ const onLogout = () => {
 
         <nav class="flex items-center gap-2">
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/profile">画像</RouterLink>
+          <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/assessment">测评</RouterLink>
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/reports">报告</RouterLink>
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/tasks">任务</RouterLink>
           <button

--- a/src/pages/AssessmentQuestionsPage.vue
+++ b/src/pages/AssessmentQuestionsPage.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { useRouter } from "vue-router";
+import { assessmentApi } from "../services/assessment";
+import { ApiError } from "../services/http";
+import { useAuthStore } from "../stores/auth";
+import type { LikertQuestion } from "../types/assessment";
+
+const auth = useAuthStore();
+const router = useRouter();
+
+const loading = ref(true);
+const submitting = ref(false);
+const errorText = ref("");
+const questions = ref<LikertQuestion[]>([]);
+const answers = ref<Record<number, number>>({});
+
+const answeredCount = computed(() => Object.keys(answers.value).length);
+
+onMounted(async () => {
+  if (!auth.state.token) {
+    loading.value = false;
+    return;
+  }
+
+  try {
+    const result = await assessmentApi.getQuestions(auth.state.token);
+    questions.value = result.questions;
+  } catch (error) {
+    errorText.value = error instanceof ApiError ? error.message : "题目加载失败";
+  } finally {
+    loading.value = false;
+  }
+});
+
+const onSubmit = async () => {
+  if (!auth.state.token) {
+    return;
+  }
+
+  submitting.value = true;
+  errorText.value = "";
+
+  const payload = questions.value.map((question) => ({
+    questionId: question.questionId,
+    score: answers.value[question.questionId] ?? 0
+  }));
+
+  try {
+    await assessmentApi.submitAnswers(auth.state.token, payload);
+    await router.push("/assessment/result");
+  } catch (error) {
+    errorText.value = error instanceof ApiError ? error.message : "提交失败";
+  } finally {
+    submitting.value = false;
+  }
+};
+</script>
+
+<template>
+  <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow">
+    <h1 class="text-xl font-bold text-slate-900">职业测评答题</h1>
+    <p class="mt-2 text-sm text-slate-600">1-5 分量表（非常不符合 → 非常符合）。</p>
+
+    <p v-if="loading" class="mt-5 text-sm text-slate-500">题目加载中...</p>
+    <p v-else-if="errorText" class="mt-5 text-sm text-rose-600">{{ errorText }}</p>
+
+    <form v-else class="mt-6 space-y-5" @submit.prevent="onSubmit">
+      <article v-for="question in questions" :key="question.questionId" class="rounded-xl border border-slate-200 p-4">
+        <p class="text-sm font-medium text-slate-900">{{ question.order }}. {{ question.text }}</p>
+        <div class="mt-3 flex gap-2">
+          <label v-for="n in 5" :key="n" class="inline-flex items-center gap-1 text-sm text-slate-700">
+            <input v-model.number="answers[question.questionId]" type="radio" :name="`q-${question.questionId}`" :value="n" required />
+            {{ n }}
+          </label>
+        </div>
+      </article>
+
+      <p class="text-sm text-slate-600">已完成 {{ answeredCount }} / {{ questions.length }} 题</p>
+      <p v-if="errorText" class="text-sm text-rose-600">{{ errorText }}</p>
+
+      <button
+        class="rounded-lg bg-brand-500 px-4 py-2 text-white disabled:cursor-not-allowed disabled:opacity-60"
+        :disabled="submitting"
+      >
+        {{ submitting ? "提交中..." : "提交测评" }}
+      </button>
+    </form>
+  </section>
+</template>

--- a/src/pages/AssessmentResultPage.vue
+++ b/src/pages/AssessmentResultPage.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { assessmentApi } from "../services/assessment";
+import { ApiError } from "../services/http";
+import { useAuthStore } from "../stores/auth";
+import type { AssessmentResultResponse } from "../types/assessment";
+
+const auth = useAuthStore();
+const loading = ref(true);
+const errorText = ref("");
+const result = ref<AssessmentResultResponse | null>(null);
+
+onMounted(async () => {
+  if (!auth.state.token) {
+    loading.value = false;
+    return;
+  }
+
+  try {
+    result.value = await assessmentApi.getResult(auth.state.token);
+  } catch (error) {
+    errorText.value = error instanceof ApiError ? error.message : "结果加载失败";
+  } finally {
+    loading.value = false;
+  }
+});
+
+const bars = computed(() => {
+  if (!result.value) {
+    return [] as Array<{ key: string; label: string; value: number }>;
+  }
+
+  const scores = result.value.dimensionScores;
+  return [
+    { key: "self", label: "自我认知", value: scores.selfCognition },
+    { key: "plan", label: "职业规划", value: scores.careerPlanning },
+    { key: "exec", label: "执行力", value: scores.executionPower }
+  ];
+});
+
+const nextActionText = computed(() => {
+  const direction = result.value?.recommendation.direction;
+  if (direction === "postgraduate") return "建议下一步：查看升学方向榜样与报告。";
+  if (direction === "civil_service") return "建议下一步：查看公考方向榜样与报告。";
+  return "建议下一步：查看就业方向榜样与报告。";
+});
+</script>
+
+<template>
+  <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow">
+    <h1 class="text-xl font-bold text-slate-900">测评结果</h1>
+
+    <p v-if="loading" class="mt-4 text-sm text-slate-500">结果加载中...</p>
+    <p v-else-if="errorText" class="mt-4 text-sm text-rose-600">{{ errorText }}</p>
+
+    <template v-else>
+      <div class="mt-5 space-y-3">
+        <article v-for="item in bars" :key="item.key">
+          <div class="mb-1 flex items-center justify-between text-sm text-slate-700">
+            <span>{{ item.label }}</span>
+            <span>{{ item.value }}</span>
+          </div>
+          <div class="h-3 rounded bg-slate-100">
+            <div class="h-3 rounded bg-brand-500" :style="{ width: `${item.value}%` }"></div>
+          </div>
+        </article>
+      </div>
+
+      <p class="mt-5 rounded-lg bg-slate-50 px-3 py-2 text-sm text-slate-700">
+        {{ result?.recommendation.summary }}
+      </p>
+
+      <p class="mt-3 text-sm font-medium text-brand-700">{{ nextActionText }}</p>
+    </template>
+  </section>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,8 @@ import { createRouter, createWebHistory } from "vue-router";
 import FirstVerifyPage from "../pages/FirstVerifyPage.vue";
 import LoginPage from "../pages/LoginPage.vue";
 import ReportsPage from "../pages/ReportsPage.vue";
+import AssessmentQuestionsPage from "../pages/AssessmentQuestionsPage.vue";
+import AssessmentResultPage from "../pages/AssessmentResultPage.vue";
 import ProfilePage from "../pages/ProfilePage.vue";
 import TasksPage from "../pages/TasksPage.vue";
 import { useAuthStore } from "../stores/auth";
@@ -13,6 +15,8 @@ const router = createRouter({
     { path: "/login", component: LoginPage },
     { path: "/first-verify", component: FirstVerifyPage, meta: { requiresAuth: true } },
     { path: "/profile", component: ProfilePage, meta: { requiresAuth: true, requiresVerified: true } },
+    { path: "/assessment", component: AssessmentQuestionsPage, meta: { requiresAuth: true, requiresVerified: true } },
+    { path: "/assessment/result", component: AssessmentResultPage, meta: { requiresAuth: true, requiresVerified: true } },
     { path: "/reports", component: ReportsPage, meta: { requiresAuth: true, requiresVerified: true } },
     { path: "/tasks", component: TasksPage, meta: { requiresAuth: true, requiresVerified: true } }
   ]

--- a/src/services/assessment.ts
+++ b/src/services/assessment.ts
@@ -1,0 +1,26 @@
+import { requestJson } from "./http";
+import type {
+  AssessmentResultResponse,
+  QuestionsResponse,
+  SubmitAnswersResponse
+} from "../types/assessment";
+
+export const assessmentApi = {
+  getQuestions(token: string) {
+    return requestJson<QuestionsResponse>("/student/assessments/questions", {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+  },
+  submitAnswers(token: string, answers: Array<{ questionId: number; score: number }>) {
+    return requestJson<SubmitAnswersResponse>("/student/assessments/submissions", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ answers })
+    });
+  },
+  getResult(token: string) {
+    return requestJson<AssessmentResultResponse>("/student/assessments/result", {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+  }
+};

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -1,0 +1,34 @@
+export interface LikertQuestion {
+  questionId: number;
+  dimension: string;
+  text: string;
+  order: number;
+}
+
+export interface QuestionsResponse {
+  questionSetVersion: string;
+  totalQuestions: number;
+  questions: LikertQuestion[];
+}
+
+export interface SubmitAnswersResponse {
+  submissionId: number;
+  questionSetVersion: string;
+  answerCount: number;
+  submittedAt: string;
+}
+
+export interface AssessmentResultResponse {
+  studentId: number;
+  questionSetVersion: string;
+  dimensionScores: {
+    selfCognition: number;
+    careerPlanning: number;
+    executionPower: number;
+  };
+  recommendation: {
+    direction: "employment" | "postgraduate" | "civil_service";
+    summary: string;
+  };
+  generatedAt: string;
+}


### PR DESCRIPTION
Closes #4

## 变更内容
- 新增测评答题页 `/assessment`
- 新增测评结果页 `/assessment/result`
- 结果页展示匹配度条形图与解释文案
- 展示下一步动作建议文案

## 验证
- `npm run build` 通过
