### PR TITLE
feat: 实现榜样案例三方向Tab与详情

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,6 +24,7 @@ const onLogout = () => {
         <nav class="flex items-center gap-2">
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/profile">画像</RouterLink>
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/assessment">测评</RouterLink>
+          <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/role-models">榜样</RouterLink>
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/reports">报告</RouterLink>
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/tasks">任务</RouterLink>
           <button

--- a/src/pages/RoleModelsPage.vue
+++ b/src/pages/RoleModelsPage.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { ApiError } from "../services/http";
+import { roleModelApi } from "../services/role-model";
+import { useAuthStore } from "../stores/auth";
+import type { RoleModelDirection, RoleModelItem } from "../types/role-model";
+
+const auth = useAuthStore();
+
+const tabs: Array<{ key: RoleModelDirection; label: string }> = [
+  { key: "employment", label: "就业" },
+  { key: "postgraduate", label: "升学" },
+  { key: "civil_service", label: "公考" }
+];
+
+const activeDirection = ref<RoleModelDirection>("employment");
+const loading = ref(false);
+const errorText = ref("");
+const models = ref<RoleModelItem[]>([]);
+const selected = ref<RoleModelItem | null>(null);
+
+const maskedModels = computed(() =>
+  models.value.map((item) => ({
+    ...item,
+    studentNoMasked:
+      item.studentNo.length > 4
+        ? `${item.studentNo.slice(0, 2)}****${item.studentNo.slice(-2)}`
+        : "****"
+  }))
+);
+
+const load = async (direction: RoleModelDirection) => {
+  if (!auth.state.token) {
+    return;
+  }
+
+  loading.value = true;
+  errorText.value = "";
+
+  try {
+    const result = await roleModelApi.list(auth.state.token, direction);
+    models.value = result.models;
+    selected.value = result.models[0] ?? null;
+  } catch (error) {
+    errorText.value = error instanceof ApiError ? error.message : "榜样案例加载失败";
+  } finally {
+    loading.value = false;
+  }
+};
+
+const onSwitch = async (direction: RoleModelDirection) => {
+  activeDirection.value = direction;
+  await load(direction);
+};
+
+onMounted(async () => {
+  await load(activeDirection.value);
+});
+</script>
+
+<template>
+  <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow">
+    <h1 class="text-xl font-bold text-slate-900">榜样案例</h1>
+    <p class="mt-2 text-sm text-slate-600">按方向查看对标案例（列表字段已脱敏）。</p>
+
+    <div class="mt-5 flex gap-2">
+      <button
+        v-for="tab in tabs"
+        :key="tab.key"
+        class="rounded-lg px-3 py-1.5 text-sm"
+        :class="activeDirection === tab.key ? 'bg-brand-500 text-white' : 'bg-slate-100 text-slate-700'"
+        @click="onSwitch(tab.key)"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+
+    <p v-if="loading" class="mt-5 text-sm text-slate-500">加载中...</p>
+    <p v-else-if="errorText" class="mt-5 text-sm text-rose-600">{{ errorText }}</p>
+
+    <div v-else class="mt-6 grid gap-4 md:grid-cols-[1.2fr_1fr]">
+      <ul class="space-y-3">
+        <li
+          v-for="item in maskedModels"
+          :key="`${activeDirection}-${item.studentNo}`"
+          class="cursor-pointer rounded-xl border p-3"
+          :class="selected?.studentNo === item.studentNo ? 'border-brand-500 bg-brand-50' : 'border-slate-200'"
+          @click="selected = item"
+        >
+          <p class="text-sm font-semibold text-slate-900">{{ item.name }}</p>
+          <p class="mt-1 text-xs text-slate-500">学号：{{ item.studentNoMasked }}</p>
+          <p class="mt-1 text-xs text-slate-500">差值：{{ item.scoreGap }}</p>
+          <div class="mt-2 flex flex-wrap gap-1">
+            <span v-for="tag in item.tags" :key="tag" class="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">{{ tag }}</span>
+          </div>
+        </li>
+      </ul>
+
+      <aside class="rounded-xl border border-slate-200 p-4" v-if="selected">
+        <h2 class="text-sm font-semibold text-slate-900">案例详情</h2>
+        <p class="mt-2 text-sm text-slate-700">对标点：{{ selected.tags.join(' / ') || '综合能力匹配' }}</p>
+        <p class="mt-2 text-sm text-slate-700">
+          毕业去向：
+          {{ activeDirection === 'employment' ? '企业就业' : activeDirection === 'postgraduate' ? '继续深造' : '公共服务岗位' }}
+        </p>
+      </aside>
+    </div>
+  </section>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import LoginPage from "../pages/LoginPage.vue";
 import ReportsPage from "../pages/ReportsPage.vue";
 import AssessmentQuestionsPage from "../pages/AssessmentQuestionsPage.vue";
 import AssessmentResultPage from "../pages/AssessmentResultPage.vue";
+import RoleModelsPage from "../pages/RoleModelsPage.vue";
 import ProfilePage from "../pages/ProfilePage.vue";
 import TasksPage from "../pages/TasksPage.vue";
 import { useAuthStore } from "../stores/auth";
@@ -17,6 +18,7 @@ const router = createRouter({
     { path: "/profile", component: ProfilePage, meta: { requiresAuth: true, requiresVerified: true } },
     { path: "/assessment", component: AssessmentQuestionsPage, meta: { requiresAuth: true, requiresVerified: true } },
     { path: "/assessment/result", component: AssessmentResultPage, meta: { requiresAuth: true, requiresVerified: true } },
+    { path: "/role-models", component: RoleModelsPage, meta: { requiresAuth: true, requiresVerified: true } },
     { path: "/reports", component: ReportsPage, meta: { requiresAuth: true, requiresVerified: true } },
     { path: "/tasks", component: TasksPage, meta: { requiresAuth: true, requiresVerified: true } }
   ]

--- a/src/services/role-model.ts
+++ b/src/services/role-model.ts
@@ -1,0 +1,12 @@
+import { requestJson } from "./http";
+import type { RoleModelDirection, RoleModelResponse } from "../types/role-model";
+
+export const roleModelApi = {
+  list(token: string, direction: RoleModelDirection) {
+    return requestJson<RoleModelResponse>(`/student/role-models/match?direction=${direction}`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+  }
+};

--- a/src/types/role-model.ts
+++ b/src/types/role-model.ts
@@ -1,0 +1,13 @@
+export type RoleModelDirection = "employment" | "postgraduate" | "civil_service";
+
+export interface RoleModelItem {
+  studentNo: string;
+  name: string;
+  scoreGap: number;
+  tags: string[];
+}
+
+export interface RoleModelResponse {
+  direction: RoleModelDirection;
+  models: RoleModelItem[];
+}


### PR DESCRIPTION
Closes #5

## 变更内容
- 新增榜样案例页面 `/role-models`
- 支持就业/升学/公考三方向 Tab 切换
- 列表字段脱敏展示（学号掩码）
- 详情展示对标点与毕业去向

## 验证
- `npm run build` 通过
