### PR TITLE
feat: 实现我的报告列表与详情渲染

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "lesi-edu-stu",
       "version": "0.1.0",
       "dependencies": {
+        "markdown-it": "^14.1.1",
         "vue": "^3.5.13",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.18",
+        "@types/markdown-it": "^14.1.2",
         "@types/node": "^22.10.2",
         "@vitejs/plugin-vue": "^5.2.1",
         "typescript": "^5.7.2",
@@ -1186,6 +1188,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
@@ -1387,6 +1414,12 @@
       "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1823,6 +1856,15 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1831,6 +1873,41 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -1925,6 +2002,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/rollup": {
@@ -2032,6 +2118,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
     "check": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "markdown-it": "^14.1.1",
     "vue": "^3.5.13",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "^22.10.2",
     "@vitejs/plugin-vue": "^5.2.1",
     "typescript": "^5.7.2",

--- a/src/pages/ReportDetailPage.vue
+++ b/src/pages/ReportDetailPage.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import MarkdownIt from "markdown-it";
+import { computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useReportStore } from "../stores/report";
+import type { ReportDirection } from "../types/report";
+
+const route = useRoute();
+const router = useRouter();
+const reportStore = useReportStore();
+const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
+
+const direction = computed(() => route.params.direction as ReportDirection);
+const markdown = computed(() => reportStore.state.reports[direction.value] || "");
+const html = computed(() => md.render(markdown.value));
+
+const title = computed(() => {
+  if (direction.value === "postgraduate") return "升学报告";
+  if (direction.value === "civil_service") return "公考报告";
+  return "就业报告";
+});
+</script>
+
+<template>
+  <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow">
+    <div class="mb-4 flex items-center justify-between">
+      <h1 class="text-xl font-bold text-slate-900">{{ title }}</h1>
+      <button class="rounded-lg bg-slate-100 px-3 py-1.5 text-sm text-slate-700" @click="router.push('/reports')">
+        返回列表
+      </button>
+    </div>
+
+    <p v-if="!markdown" class="rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-700">报告内容暂不可用，请返回重试。</p>
+
+    <article
+      v-else
+      class="prose prose-slate max-w-none prose-table:border prose-table:border-slate-200 prose-th:bg-slate-50"
+      v-html="html"
+    ></article>
+  </section>
+</template>

--- a/src/pages/ReportsPage.vue
+++ b/src/pages/ReportsPage.vue
@@ -1,6 +1,81 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { useRouter } from "vue-router";
+import { ApiError } from "../services/http";
+import { useReportStore } from "../stores/report";
+import { useAuthStore } from "../stores/auth";
+import type { ReportDirection } from "../types/report";
+
+const auth = useAuthStore();
+const reportStore = useReportStore();
+const router = useRouter();
+
+const loading = ref(true);
+const errorText = ref("");
+
+const reportMeta: Array<{ direction: ReportDirection; title: string }> = [
+  { direction: "employment", title: "就业报告" },
+  { direction: "postgraduate", title: "升学报告" },
+  { direction: "civil_service", title: "公考报告" }
+];
+
+const items = computed(() =>
+  reportMeta.map((meta) => ({
+    ...meta,
+    exists: Boolean(reportStore.state.reports[meta.direction])
+  }))
+);
+
+onMounted(async () => {
+  loading.value = true;
+  errorText.value = "";
+
+  try {
+    if (!auth.state.token) {
+      throw new Error("未登录");
+    }
+    await reportStore.ensureLoaded(auth.state.token);
+  } catch (error) {
+    if (error instanceof ApiError) {
+      errorText.value = `报告加载失败：${error.message}`;
+    } else {
+      errorText.value = "报告加载失败，请稍后重试。";
+    }
+  } finally {
+    loading.value = false;
+  }
+});
+
+const openDetail = async (direction: ReportDirection) => {
+  await router.push(`/reports/${direction}`);
+};
+</script>
+
 <template>
   <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow">
     <h1 class="text-xl font-bold text-slate-900">我的报告</h1>
-    <p class="mt-2 text-sm text-slate-600">首次校验通过后可访问报告页面。</p>
+    <p class="mt-2 text-sm text-slate-600">可查看就业/升学/公考三份报告。</p>
+
+    <p v-if="loading" class="mt-5 text-sm text-slate-500">加载中...</p>
+    <p v-else-if="errorText" class="mt-5 rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-700">{{ errorText }}</p>
+
+    <ul v-else class="mt-6 space-y-3">
+      <li v-for="item in items" :key="item.direction" class="rounded-xl border border-slate-200 p-4">
+        <div class="flex items-center justify-between gap-3">
+          <div>
+            <p class="text-sm font-semibold text-slate-900">{{ item.title }}</p>
+            <p class="mt-1 text-xs text-slate-500">状态：{{ item.exists ? "已生成" : "未生成" }}</p>
+          </div>
+
+          <button
+            class="rounded-lg bg-brand-500 px-3 py-1.5 text-sm text-white disabled:opacity-40"
+            :disabled="!item.exists"
+            @click="openDetail(item.direction)"
+          >
+            查看详情
+          </button>
+        </div>
+      </li>
+    </ul>
   </section>
 </template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import FirstVerifyPage from "../pages/FirstVerifyPage.vue";
 import LoginPage from "../pages/LoginPage.vue";
 import ReportsPage from "../pages/ReportsPage.vue";
+import ReportDetailPage from "../pages/ReportDetailPage.vue";
 import AssessmentQuestionsPage from "../pages/AssessmentQuestionsPage.vue";
 import AssessmentResultPage from "../pages/AssessmentResultPage.vue";
 import RoleModelsPage from "../pages/RoleModelsPage.vue";
@@ -20,6 +21,7 @@ const router = createRouter({
     { path: "/assessment/result", component: AssessmentResultPage, meta: { requiresAuth: true, requiresVerified: true } },
     { path: "/role-models", component: RoleModelsPage, meta: { requiresAuth: true, requiresVerified: true } },
     { path: "/reports", component: ReportsPage, meta: { requiresAuth: true, requiresVerified: true } },
+    { path: "/reports/:direction", component: ReportDetailPage, meta: { requiresAuth: true, requiresVerified: true } },
     { path: "/tasks", component: TasksPage, meta: { requiresAuth: true, requiresVerified: true } }
   ]
 });

--- a/src/services/report.ts
+++ b/src/services/report.ts
@@ -1,0 +1,13 @@
+import { requestJson } from "./http";
+import type { GenerateReportsResponse } from "../types/report";
+
+export const reportApi = {
+  generate(token: string) {
+    return requestJson<GenerateReportsResponse>("/student/reports/generate", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+  }
+};

--- a/src/stores/report.ts
+++ b/src/stores/report.ts
@@ -1,0 +1,40 @@
+import { reactive } from "vue";
+import { reportApi } from "../services/report";
+import type { ReportDirection } from "../types/report";
+
+interface ReportState {
+  loaded: boolean;
+  jobId: number | null;
+  status: string | null;
+  reports: Record<ReportDirection, string>;
+}
+
+const state = reactive<ReportState>({
+  loaded: false,
+  jobId: null,
+  status: null,
+  reports: {
+    employment: "",
+    postgraduate: "",
+    civil_service: ""
+  }
+});
+
+export const useReportStore = () => {
+  const ensureLoaded = async (token: string) => {
+    if (state.loaded) {
+      return;
+    }
+
+    const result = await reportApi.generate(token);
+    state.reports = result.reports;
+    state.jobId = result.jobId;
+    state.status = result.status;
+    state.loaded = true;
+  };
+
+  return {
+    state,
+    ensureLoaded
+  };
+};

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -1,0 +1,7 @@
+export type ReportDirection = "employment" | "postgraduate" | "civil_service";
+
+export interface GenerateReportsResponse {
+  reports: Record<ReportDirection, string>;
+  jobId: number;
+  status: string;
+}


### PR DESCRIPTION
Closes #6

## 变更内容
- 新增报告列表页（就业/升学/公考）
- 新增报告详情页 `/reports/:direction`
- Markdown 内容渲染支持（含表格/清单等）
- 报告加载失败提供降级提示

## 验证
- `npm run build` 通过
