### PR TITLE
feat: stu 接入统一会话鉴权与 Bearer 链路

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/markdown-it": "^14.1.2",
         "@types/node": "^22.10.2",
         "@vitejs/plugin-vue": "^5.2.1",
+        "tailwindcss": "^4.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.5",
         "vue-tsc": "^2.2.0"
@@ -1131,6 +1132,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^22.10.2",
     "@vitejs/plugin-vue": "^5.2.1",
+    "tailwindcss": "^4.2.1",
     "typescript": "^5.7.2",
     "vite": "^6.0.5",
     "vue-tsc": "^2.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1423 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      markdown-it:
+        specifier: ^14.1.1
+        version: 14.1.1
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.29(typescript@5.9.3)
+      vue-router:
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.29(typescript@5.9.3))
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.2.1(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.13
+      '@vitejs/plugin-vue':
+        specifier: ^5.2.1
+        version: 5.2.4(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1))(vue@3.5.29(typescript@5.9.3))
+      tailwindcss:
+        specifier: ^4.2.1
+        version: 4.2.1
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.5
+        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)
+      vue-tsc:
+        specifier: ^2.2.0
+        version: 2.2.12(typescript@5.9.3)
+
+packages:
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/node@4.2.1':
+    resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.1':
+    resolution: {integrity: sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.1':
+    resolution: {integrity: sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.1':
+    resolution: {integrity: sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.1':
+    resolution: {integrity: sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+    resolution: {integrity: sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+    resolution: {integrity: sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+    resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+    resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+    resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+    resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+    resolution: {integrity: sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+    resolution: {integrity: sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.1':
+    resolution: {integrity: sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.1':
+    resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/node@22.19.13':
+    resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
+
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
+
+  '@volar/language-core@2.4.15':
+    resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
+
+  '@volar/source-map@2.4.15':
+    resolution: {integrity: sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==}
+
+  '@volar/typescript@2.4.15':
+    resolution: {integrity: sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==}
+
+  '@vue/compiler-core@3.5.29':
+    resolution: {integrity: sha512-cuzPhD8fwRHk8IGfmYaR4eEe4cAyJEL66Ove/WZL7yWNL134nqLddSLwNRIsFlnnW1kK+p8Ck3viFnC0chXCXw==}
+
+  '@vue/compiler-dom@3.5.29':
+    resolution: {integrity: sha512-n0G5o7R3uBVmVxjTIYcz7ovr8sy7QObFG8OQJ3xGCDNhbG60biP/P5KnyY8NLd81OuT1WJflG7N4KWYHaeeaIg==}
+
+  '@vue/compiler-sfc@3.5.29':
+    resolution: {integrity: sha512-oJZhN5XJs35Gzr50E82jg2cYdZQ78wEwvRO6Y63TvLVTc+6xICzJHP1UIecdSPPYIbkautNBanDiWYa64QSFIA==}
+
+  '@vue/compiler-ssr@3.5.29':
+    resolution: {integrity: sha512-Y/ARJZE6fpjzL5GH/phJmsFwx3g6t2KmHKHx5q+MLl2kencADKIrhH5MLF6HHpRMmlRAYBRSvv347Mepf1zVNw==}
+
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
+
+  '@vue/language-core@2.2.12':
+    resolution: {integrity: sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/reactivity@3.5.29':
+    resolution: {integrity: sha512-zcrANcrRdcLtmGZETBxWqIkoQei8HaFpZWx/GHKxx79JZsiZ8j1du0VUJtu4eJjgFvU/iKL5lRXFXksVmI+5DA==}
+
+  '@vue/runtime-core@3.5.29':
+    resolution: {integrity: sha512-8DpW2QfdwIWOLqtsNcds4s+QgwSaHSJY/SUe04LptianUQ/0xi6KVsu/pYVh+HO3NTVvVJjIPL2t6GdeKbS4Lg==}
+
+  '@vue/runtime-dom@3.5.29':
+    resolution: {integrity: sha512-AHvvJEtcY9tw/uk+s/YRLSlxxQnqnAkjqvK25ZiM4CllCZWzElRAoQnCM42m9AHRLNJ6oe2kC5DCgD4AUdlvXg==}
+
+  '@vue/server-renderer@3.5.29':
+    resolution: {integrity: sha512-G/1k6WK5MusLlbxSE2YTcqAAezS+VuwHhOvLx2KnQU7G2zCH6KIb+5Wyt6UjMq7a3qPzNEjJXs1hvAxDclQH+g==}
+    peerDependencies:
+      vue: 3.5.29
+
+  '@vue/shared@3.5.29':
+    resolution: {integrity: sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==}
+
+  alien-signals@1.0.13:
+    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  enhanced-resolve@5.20.0:
+    resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
+    engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  lightningcss-android-arm64@1.31.1:
+    resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.31.1:
+    resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.31.1:
+    resolution: {integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.31.1:
+    resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.31.1:
+    resolution: {integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.31.1:
+    resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.31.1:
+    resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.31.1:
+    resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.31.1:
+    resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.31.1:
+    resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.31.1:
+    resolution: {integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.31.1:
+    resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
+    engines: {node: '>= 12.0.0'}
+
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tailwindcss@4.2.1:
+    resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
+
+  tapable@2.3.0:
+    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite@6.4.1:
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  vue-tsc@2.2.12:
+    resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
+  vue@3.5.29:
+    resolution: {integrity: sha512-BZqN4Ze6mDQVNAni0IHeMJ5mwr8VAJ3MQC9FmprRhcBYENw+wOAAjRj8jfmN6FLl0j96OXbR+CjWhmAmM+QGnA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+snapshots:
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@tailwindcss/node@4.2.1':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.0
+      jiti: 2.6.1
+      lightningcss: 1.31.1
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.1
+
+  '@tailwindcss/oxide-android-arm64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.1':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.1
+      '@tailwindcss/oxide-darwin-arm64': 4.2.1
+      '@tailwindcss/oxide-darwin-x64': 4.2.1
+      '@tailwindcss/oxide-freebsd-x64': 4.2.1
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.1
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.1
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.1
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.1
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.1
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.1
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
+
+  '@tailwindcss/vite@4.2.1(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1))':
+    dependencies:
+      '@tailwindcss/node': 4.2.1
+      '@tailwindcss/oxide': 4.2.1
+      tailwindcss: 4.2.1
+      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)
+
+  '@types/estree@1.0.8': {}
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
+  '@types/node@22.19.13':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1))(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)
+      vue: 3.5.29(typescript@5.9.3)
+
+  '@volar/language-core@2.4.15':
+    dependencies:
+      '@volar/source-map': 2.4.15
+
+  '@volar/source-map@2.4.15': {}
+
+  '@volar/typescript@2.4.15':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vue/compiler-core@3.5.29':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@vue/shared': 3.5.29
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.29':
+    dependencies:
+      '@vue/compiler-core': 3.5.29
+      '@vue/shared': 3.5.29
+
+  '@vue/compiler-sfc@3.5.29':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@vue/compiler-core': 3.5.29
+      '@vue/compiler-dom': 3.5.29
+      '@vue/compiler-ssr': 3.5.29
+      '@vue/shared': 3.5.29
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.8
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.29':
+    dependencies:
+      '@vue/compiler-dom': 3.5.29
+      '@vue/shared': 3.5.29
+
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
+  '@vue/devtools-api@6.6.4': {}
+
+  '@vue/language-core@2.2.12(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      '@vue/compiler-dom': 3.5.29
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.29
+      alien-signals: 1.0.13
+      minimatch: 9.0.9
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@vue/reactivity@3.5.29':
+    dependencies:
+      '@vue/shared': 3.5.29
+
+  '@vue/runtime-core@3.5.29':
+    dependencies:
+      '@vue/reactivity': 3.5.29
+      '@vue/shared': 3.5.29
+
+  '@vue/runtime-dom@3.5.29':
+    dependencies:
+      '@vue/reactivity': 3.5.29
+      '@vue/runtime-core': 3.5.29
+      '@vue/shared': 3.5.29
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.29(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.29
+      '@vue/shared': 3.5.29
+      vue: 3.5.29(typescript@5.9.3)
+
+  '@vue/shared@3.5.29': {}
+
+  alien-signals@1.0.13: {}
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  csstype@3.2.3: {}
+
+  de-indent@1.0.2: {}
+
+  detect-libc@2.1.2: {}
+
+  enhanced-resolve@5.20.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.0
+
+  entities@4.5.0: {}
+
+  entities@7.0.1: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  estree-walker@2.0.2: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  graceful-fs@4.2.11: {}
+
+  he@1.2.0: {}
+
+  jiti@2.6.1: {}
+
+  lightningcss-android-arm64@1.31.1:
+    optional: true
+
+  lightningcss-darwin-arm64@1.31.1:
+    optional: true
+
+  lightningcss-darwin-x64@1.31.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.31.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.31.1:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.31.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.31.1:
+    optional: true
+
+  lightningcss@1.31.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.31.1
+      lightningcss-darwin-arm64: 1.31.1
+      lightningcss-darwin-x64: 1.31.1
+      lightningcss-freebsd-x64: 1.31.1
+      lightningcss-linux-arm-gnueabihf: 1.31.1
+      lightningcss-linux-arm64-gnu: 1.31.1
+      lightningcss-linux-arm64-musl: 1.31.1
+      lightningcss-linux-x64-gnu: 1.31.1
+      lightningcss-linux-x64-musl: 1.31.1
+      lightningcss-win32-arm64-msvc: 1.31.1
+      lightningcss-win32-x64-msvc: 1.31.1
+
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  mdurl@2.0.0: {}
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  muggle-string@0.4.1: {}
+
+  nanoid@3.3.11: {}
+
+  path-browserify@1.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  punycode.js@2.3.1: {}
+
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  source-map-js@1.2.1: {}
+
+  tailwindcss@4.2.1: {}
+
+  tapable@2.3.0: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
+
+  undici-types@6.21.0: {}
+
+  vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.13
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.31.1
+
+  vscode-uri@3.1.0: {}
+
+  vue-router@4.6.4(vue@3.5.29(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.29(typescript@5.9.3)
+
+  vue-tsc@2.2.12(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.15
+      '@vue/language-core': 2.2.12(typescript@5.9.3)
+      typescript: 5.9.3
+
+  vue@3.5.29(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.29
+      '@vue/compiler-sfc': 3.5.29
+      '@vue/runtime-dom': 3.5.29
+      '@vue/server-renderer': 3.5.29(vue@3.5.29(typescript@5.9.3))
+      '@vue/shared': 3.5.29
+    optionalDependencies:
+      typescript: 5.9.3

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,24 +1,31 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useAuthStore } from "./stores/auth";
+import { useReportStore } from "./stores/report";
 
 const route = useRoute();
 const router = useRouter();
 const auth = useAuthStore();
+const reportStore = useReportStore();
 
-const onLogout = () => {
-  auth.logout();
-  router.replace("/login");
+const user = computed(() => auth.state.user);
+
+const onLogout = async () => {
+  await auth.logout();
+  reportStore.reset();
+  await router.replace("/login");
 };
 </script>
 
 <template>
   <main class="mx-auto flex min-h-screen max-w-5xl flex-col px-6 py-10">
-    <header class="mb-6 rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+    <header v-if="auth.state.initialized && user" class="mb-6 rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div>
           <p class="text-xs uppercase tracking-[0.18em] text-slate-500">LESI EDU</p>
           <h1 class="text-lg font-bold text-slate-900">学生端</h1>
+          <p class="mt-1 text-xs text-slate-500">{{ user.displayName }}（{{ user.account }}）</p>
         </div>
 
         <nav class="flex items-center gap-2">
@@ -27,13 +34,7 @@ const onLogout = () => {
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/role-models">榜样</RouterLink>
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/reports">报告</RouterLink>
           <RouterLink class="rounded-lg px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100" to="/tasks">任务</RouterLink>
-          <button
-            v-if="auth.isLoggedIn.value"
-            class="rounded-lg bg-slate-900 px-3 py-1.5 text-sm text-white"
-            @click="onLogout"
-          >
-            退出
-          </button>
+          <button class="rounded-lg bg-slate-900 px-3 py-1.5 text-sm text-white" @click="onLogout">退出</button>
         </nav>
       </div>
 
@@ -42,6 +43,7 @@ const onLogout = () => {
       </p>
     </header>
 
-    <RouterView />
+    <p v-if="!auth.state.initialized" class="mt-16 text-center text-sm text-slate-500">正在恢复登录态...</p>
+    <RouterView v-else />
   </main>
 </template>

--- a/src/constants/rbac.ts
+++ b/src/constants/rbac.ts
@@ -1,0 +1,31 @@
+import type { AuthRole } from "../types/auth";
+
+export const ROLE_PERMISSIONS: Record<AuthRole, string[]> = {
+  student: [
+    "student.profile.read",
+    "student.assessment.submit",
+    "report.read",
+    "task.read",
+    "task.checkin.submit",
+    "certificate.upload"
+  ],
+  teacher: [
+    "teacher.students.read",
+    "teacher.student.detail.read",
+    "teacher.activity.execute",
+    "report.read",
+    "task.read",
+    "student.profile.read"
+  ],
+  admin: [
+    "admin.org.manage",
+    "admin.teacher.manage",
+    "admin.authorization.manage",
+    "admin.activity.publish",
+    "admin.dashboard.read"
+  ]
+};
+
+export const getPermissionsByRole = (role: AuthRole): string[] => {
+  return ROLE_PERMISSIONS[role] ?? [];
+};

--- a/src/pages/AssessmentQuestionsPage.vue
+++ b/src/pages/AssessmentQuestionsPage.vue
@@ -3,10 +3,8 @@ import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
 import { assessmentApi } from "../services/assessment";
 import { ApiError } from "../services/http";
-import { useAuthStore } from "../stores/auth";
 import type { LikertQuestion } from "../types/assessment";
 
-const auth = useAuthStore();
 const router = useRouter();
 
 const loading = ref(true);
@@ -18,13 +16,8 @@ const answers = ref<Record<number, number>>({});
 const answeredCount = computed(() => Object.keys(answers.value).length);
 
 onMounted(async () => {
-  if (!auth.state.token) {
-    loading.value = false;
-    return;
-  }
-
   try {
-    const result = await assessmentApi.getQuestions(auth.state.token);
+    const result = await assessmentApi.getQuestions();
     questions.value = result.questions;
   } catch (error) {
     errorText.value = error instanceof ApiError ? error.message : "题目加载失败";
@@ -34,10 +27,6 @@ onMounted(async () => {
 });
 
 const onSubmit = async () => {
-  if (!auth.state.token) {
-    return;
-  }
-
   submitting.value = true;
   errorText.value = "";
 
@@ -47,7 +36,7 @@ const onSubmit = async () => {
   }));
 
   try {
-    await assessmentApi.submitAnswers(auth.state.token, payload);
+    await assessmentApi.submitAnswers(payload);
     await router.push("/assessment/result");
   } catch (error) {
     errorText.value = error instanceof ApiError ? error.message : "提交失败";

--- a/src/pages/AssessmentResultPage.vue
+++ b/src/pages/AssessmentResultPage.vue
@@ -2,22 +2,15 @@
 import { computed, onMounted, ref } from "vue";
 import { assessmentApi } from "../services/assessment";
 import { ApiError } from "../services/http";
-import { useAuthStore } from "../stores/auth";
 import type { AssessmentResultResponse } from "../types/assessment";
 
-const auth = useAuthStore();
 const loading = ref(true);
 const errorText = ref("");
 const result = ref<AssessmentResultResponse | null>(null);
 
 onMounted(async () => {
-  if (!auth.state.token) {
-    loading.value = false;
-    return;
-  }
-
   try {
-    result.value = await assessmentApi.getResult(auth.state.token);
+    result.value = await assessmentApi.getResult();
   } catch (error) {
     errorText.value = error instanceof ApiError ? error.message : "结果加载失败";
   } finally {

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -1,29 +1,47 @@
 <script setup lang="ts">
 import { reactive, ref } from "vue";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { ApiError } from "../services/http";
-import { useAuthStore } from "../stores/auth";
+import { getDefaultRouteByRole, useAuthStore } from "../stores/auth";
 
 const auth = useAuthStore();
+const route = useRoute();
 const router = useRouter();
 
 const form = reactive({
-  studentNo: "",
+  account: "",
   password: ""
 });
 
 const submitting = ref(false);
 const errorText = ref("");
 
+const resolveRedirect = (): string => {
+  const redirect = route.query.redirect;
+  if (typeof redirect === "string" && redirect.startsWith("/")) {
+    return redirect;
+  }
+
+  if (auth.state.user) {
+    return getDefaultRouteByRole(auth.state.user.role);
+  }
+
+  return "/reports";
+};
+
 const onSubmit = async () => {
   submitting.value = true;
   errorText.value = "";
 
   try {
-    await auth.login({ studentNo: form.studentNo, password: form.password });
-    await router.replace("/first-verify");
+    await auth.loginByAccount({
+      account: form.account,
+      password: form.password
+    });
+
+    await router.replace(resolveRedirect());
   } catch (error) {
-    if (error instanceof ApiError) {
+    if (error instanceof ApiError || error instanceof Error) {
       errorText.value = error.message;
     } else {
       errorText.value = "登录失败，请稍后重试";
@@ -37,12 +55,12 @@ const onSubmit = async () => {
 <template>
   <section class="mx-auto max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow">
     <h1 class="text-xl font-bold text-slate-900">学生登录</h1>
-    <p class="mt-2 text-sm text-slate-600">请输入学号和密码登录系统。</p>
+    <p class="mt-2 text-sm text-slate-600">请输入学号（账号）和密码登录系统。</p>
 
     <form class="mt-6 space-y-4" @submit.prevent="onSubmit">
       <label class="block text-sm">
-        <span class="mb-1 block text-slate-700">学号</span>
-        <input v-model="form.studentNo" class="w-full rounded-lg border border-slate-300 px-3 py-2" required />
+        <span class="mb-1 block text-slate-700">学号/账号</span>
+        <input v-model="form.account" class="w-full rounded-lg border border-slate-300 px-3 py-2" required />
       </label>
       <label class="block text-sm">
         <span class="mb-1 block text-slate-700">密码</span>

--- a/src/pages/ProfilePage.vue
+++ b/src/pages/ProfilePage.vue
@@ -2,10 +2,8 @@
 import { computed, onMounted, ref } from "vue";
 import { ApiError } from "../services/http";
 import { profileApi } from "../services/profile";
-import { useAuthStore } from "../stores/auth";
 import type { EnrollmentProfile } from "../types/profile";
 
-const auth = useAuthStore();
 const loading = ref(true);
 const errorText = ref("");
 const profile = ref<EnrollmentProfile | null>(null);
@@ -25,13 +23,8 @@ const tags = computed(() => {
 });
 
 onMounted(async () => {
-  if (!auth.state.token) {
-    loading.value = false;
-    return;
-  }
-
   try {
-    const result = await profileApi.getEnrollmentProfile(auth.state.token);
+    const result = await profileApi.getEnrollmentProfile();
     profile.value = result.profile;
   } catch (error) {
     if (error instanceof ApiError) {

--- a/src/pages/ReportsPage.vue
+++ b/src/pages/ReportsPage.vue
@@ -31,10 +31,7 @@ onMounted(async () => {
   errorText.value = "";
 
   try {
-    if (!auth.state.token) {
-      throw new Error("未登录");
-    }
-    await reportStore.ensureLoaded(auth.state.token);
+    await reportStore.ensureLoaded(auth.state.user?.userId ?? "");
   } catch (error) {
     if (error instanceof ApiError) {
       errorText.value = `报告加载失败：${error.message}`;

--- a/src/pages/RoleModelsPage.vue
+++ b/src/pages/RoleModelsPage.vue
@@ -2,10 +2,7 @@
 import { computed, onMounted, ref } from "vue";
 import { ApiError } from "../services/http";
 import { roleModelApi } from "../services/role-model";
-import { useAuthStore } from "../stores/auth";
 import type { RoleModelDirection, RoleModelItem } from "../types/role-model";
-
-const auth = useAuthStore();
 
 const tabs: Array<{ key: RoleModelDirection; label: string }> = [
   { key: "employment", label: "就业" },
@@ -30,15 +27,11 @@ const maskedModels = computed(() =>
 );
 
 const load = async (direction: RoleModelDirection) => {
-  if (!auth.state.token) {
-    return;
-  }
-
   loading.value = true;
   errorText.value = "";
 
   try {
-    const result = await roleModelApi.list(auth.state.token, direction);
+    const result = await roleModelApi.list(direction);
     models.value = result.models;
     selected.value = result.models[0] ?? null;
   } catch (error) {

--- a/src/pages/TasksPage.vue
+++ b/src/pages/TasksPage.vue
@@ -2,10 +2,7 @@
 import { computed, reactive, ref } from "vue";
 import { ApiError } from "../services/http";
 import { submitTaskCheckIn, uploadCertificate } from "../services/task";
-import { useAuthStore } from "../stores/auth";
 import type { TaskDirection, TaskItem, TaskStatus } from "../types/task";
-
-const auth = useAuthStore();
 
 const filters = reactive<{
   semester: string;
@@ -79,7 +76,7 @@ const onFileChange = (event: Event) => {
 };
 
 const submit = async () => {
-  if (!auth.state.token || !modalTask.value || !uploadFile.value) {
+  if (!modalTask.value || !uploadFile.value) {
     feedback.value = "请先选择附件。";
     return;
   }
@@ -88,8 +85,8 @@ const submit = async () => {
   feedback.value = "";
 
   try {
-    const upload = await uploadCertificate(auth.state.token, uploadFile.value);
-    await submitTaskCheckIn(auth.state.token, modalTask.value.id, {
+    const upload = await uploadCertificate(uploadFile.value);
+    await submitTaskCheckIn(modalTask.value.id, {
       fileId: upload.fileId,
       note: note.value
     });

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,33 +8,123 @@ import AssessmentResultPage from "../pages/AssessmentResultPage.vue";
 import RoleModelsPage from "../pages/RoleModelsPage.vue";
 import ProfilePage from "../pages/ProfilePage.vue";
 import TasksPage from "../pages/TasksPage.vue";
-import { useAuthStore } from "../stores/auth";
+import { getDefaultRouteByRole, useAuthStore } from "../stores/auth";
+import type { AuthRole } from "../types/auth";
+
+declare module "vue-router" {
+  interface RouteMeta {
+    requiresAuth?: boolean;
+    requiresVerified?: boolean;
+    guestOnly?: boolean;
+    roles?: AuthRole[];
+    permissions?: string[];
+  }
+}
 
 const router = createRouter({
   history: createWebHistory(),
   routes: [
-    { path: "/", redirect: "/login" },
-    { path: "/login", component: LoginPage },
-    { path: "/first-verify", component: FirstVerifyPage, meta: { requiresAuth: true } },
-    { path: "/profile", component: ProfilePage, meta: { requiresAuth: true, requiresVerified: true } },
-    { path: "/assessment", component: AssessmentQuestionsPage, meta: { requiresAuth: true, requiresVerified: true } },
-    { path: "/assessment/result", component: AssessmentResultPage, meta: { requiresAuth: true, requiresVerified: true } },
-    { path: "/role-models", component: RoleModelsPage, meta: { requiresAuth: true, requiresVerified: true } },
-    { path: "/reports", component: ReportsPage, meta: { requiresAuth: true, requiresVerified: true } },
-    { path: "/reports/:direction", component: ReportDetailPage, meta: { requiresAuth: true, requiresVerified: true } },
-    { path: "/tasks", component: TasksPage, meta: { requiresAuth: true, requiresVerified: true } }
+    {
+      path: "/",
+      redirect: () => {
+        const auth = useAuthStore();
+        if (!auth.state.user) {
+          return "/login";
+        }
+        return getDefaultRouteByRole(auth.state.user.role);
+      }
+    },
+    { path: "/login", component: LoginPage, meta: { requiresAuth: false, guestOnly: true } },
+    {
+      path: "/first-verify",
+      component: FirstVerifyPage,
+      meta: { requiresAuth: true, roles: ["student"] }
+    },
+    {
+      path: "/profile",
+      component: ProfilePage,
+      meta: { requiresAuth: true, requiresVerified: true, roles: ["student"], permissions: ["student.profile.read"] }
+    },
+    {
+      path: "/assessment",
+      component: AssessmentQuestionsPage,
+      meta: {
+        requiresAuth: true,
+        requiresVerified: true,
+        roles: ["student"],
+        permissions: ["student.assessment.submit"]
+      }
+    },
+    {
+      path: "/assessment/result",
+      component: AssessmentResultPage,
+      meta: {
+        requiresAuth: true,
+        requiresVerified: true,
+        roles: ["student"],
+        permissions: ["student.assessment.submit"]
+      }
+    },
+    {
+      path: "/role-models",
+      component: RoleModelsPage,
+      meta: { requiresAuth: true, requiresVerified: true, roles: ["student"] }
+    },
+    {
+      path: "/reports",
+      component: ReportsPage,
+      meta: { requiresAuth: true, requiresVerified: true, roles: ["student"], permissions: ["report.read"] }
+    },
+    {
+      path: "/reports/:direction",
+      component: ReportDetailPage,
+      meta: { requiresAuth: true, requiresVerified: true, roles: ["student"], permissions: ["report.read"] }
+    },
+    {
+      path: "/tasks",
+      component: TasksPage,
+      meta: { requiresAuth: true, requiresVerified: true, roles: ["student"], permissions: ["task.read"] }
+    },
+    {
+      path: "/:pathMatch(.*)*",
+      redirect: "/"
+    }
   ]
 });
 
-router.beforeEach((to) => {
+router.beforeEach(async (to) => {
   const auth = useAuthStore();
 
-  if (to.meta.requiresAuth && !auth.isLoggedIn.value) {
+  if (!auth.state.initialized) {
+    await auth.initialize();
+  }
+
+  if (to.meta.guestOnly && auth.isLoggedIn.value) {
+    return getDefaultRouteByRole(auth.state.user!.role);
+  }
+
+  const requiresAuth = to.meta.requiresAuth !== false;
+
+  if (requiresAuth && !auth.isLoggedIn.value) {
+    return {
+      path: "/login",
+      query: {
+        redirect: to.fullPath
+      }
+    };
+  }
+
+  if (auth.state.user && auth.state.user.role !== "student") {
+    await auth.logout();
     return "/login";
   }
 
-  if (to.path === "/login" && auth.isLoggedIn.value) {
-    return auth.requiresFirstVerify.value ? "/first-verify" : "/reports";
+  if (to.meta.roles && !auth.hasRole(to.meta.roles)) {
+    return "/login";
+  }
+
+  if (to.meta.permissions && !auth.hasPermissions(to.meta.permissions)) {
+    return "/login";
   }
 
   if (to.meta.requiresVerified && auth.requiresFirstVerify.value) {

--- a/src/services/assessment.ts
+++ b/src/services/assessment.ts
@@ -6,21 +6,19 @@ import type {
 } from "../types/assessment";
 
 export const assessmentApi = {
-  getQuestions(token: string) {
-    return requestJson<QuestionsResponse>("/student/assessments/questions", {
-      headers: { Authorization: `Bearer ${token}` }
-    });
+  getQuestions() {
+    return requestJson<QuestionsResponse>("/student/assessments/questions");
   },
-  submitAnswers(token: string, answers: Array<{ questionId: number; score: number }>) {
+  submitAnswers(answers: Array<{ questionId: number; score: number }>) {
     return requestJson<SubmitAnswersResponse>("/student/assessments/submissions", {
       method: "POST",
-      headers: { Authorization: `Bearer ${token}` },
+      headers: {
+        "content-type": "application/json"
+      },
       body: JSON.stringify({ answers })
     });
   },
-  getResult(token: string) {
-    return requestJson<AssessmentResultResponse>("/student/assessments/result", {
-      headers: { Authorization: `Bearer ${token}` }
-    });
+  getResult() {
+    return requestJson<AssessmentResultResponse>("/student/assessments/result");
   }
 };

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,18 +1,45 @@
 import { requestJson } from "./http";
-import type { FirstLoginVerifyPayload, FirstLoginVerifyResponse, StudentLoginResponse } from "../types/auth";
+import type {
+  FirstLoginVerifyPayload,
+  FirstLoginVerifyResponse,
+  AuthUser,
+  UnifiedLoginResponse
+} from "../types/auth";
 
 export const authApi = {
-  login(payload: { studentNo: string; password: string }) {
-    return requestJson<StudentLoginResponse>("/auth/student/login", {
+  login(payload: { account: string; password: string }) {
+    return requestJson<UnifiedLoginResponse>("/auth/login", {
       method: "POST",
-      body: JSON.stringify(payload)
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(payload),
+      auth: false,
+      retryOnAuthFail: false
     });
   },
-  firstLoginVerify(token: string, payload: FirstLoginVerifyPayload) {
+  refresh() {
+    return requestJson<UnifiedLoginResponse>("/auth/refresh", {
+      method: "POST",
+      auth: false,
+      retryOnAuthFail: false
+    });
+  },
+  logout() {
+    return requestJson<{ message: string }>("/auth/logout", {
+      method: "POST",
+      auth: false,
+      retryOnAuthFail: false
+    });
+  },
+  me() {
+    return requestJson<AuthUser>("/auth/me");
+  },
+  firstLoginVerify(payload: FirstLoginVerifyPayload) {
     return requestJson<FirstLoginVerifyResponse>("/auth/student/first-login-verify", {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${token}`
+        "content-type": "application/json"
       },
       body: JSON.stringify(payload)
     });

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -11,25 +11,124 @@ export class ApiError extends Error {
   }
 }
 
-export async function requestJson<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    ...init,
-    headers: {
-      "content-type": "application/json",
-      ...(init.headers ?? {})
-    }
-  });
+export interface RequestJsonOptions extends RequestInit {
+  auth?: boolean;
+  retryOnAuthFail?: boolean;
+}
 
-  const text = await response.text();
-  const payload = text ? JSON.parse(text) : null;
+let accessToken: string | null = null;
+let refreshAccessTokenHandler: (() => Promise<string | null>) | null = null;
+let unauthorizedHandler: (() => void) | null = null;
+let refreshInFlight: Promise<string | null> | null = null;
 
-  if (!response.ok) {
-    throw new ApiError(
-      (payload as { message?: string } | null)?.message || `请求失败(${response.status})`,
-      response.status,
-      payload
-    );
+export const setAccessToken = (token: string | null) => {
+  accessToken = token && token.trim().length > 0 ? token.trim() : null;
+};
+
+export const getAccessToken = (): string | null => {
+  return accessToken;
+};
+
+export const configureAuthLifecycle = (input: {
+  onRefreshAccessToken?: (() => Promise<string | null>) | null;
+  onUnauthorized?: (() => void) | null;
+}) => {
+  refreshAccessTokenHandler = input.onRefreshAccessToken ?? null;
+  unauthorizedHandler = input.onUnauthorized ?? null;
+};
+
+const parseJsonSafely = (text: string): unknown => {
+  if (!text) {
+    return null;
   }
 
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+};
+
+const runRefreshTokenFlow = async (): Promise<string | null> => {
+  if (!refreshAccessTokenHandler) {
+    return null;
+  }
+
+  if (!refreshInFlight) {
+    refreshInFlight = refreshAccessTokenHandler()
+      .catch(() => null)
+      .finally(() => {
+        refreshInFlight = null;
+      });
+  }
+
+  return refreshInFlight;
+};
+
+const buildHeaders = ({
+  headers,
+  auth,
+  token
+}: {
+  headers: HeadersInit | undefined;
+  auth: boolean;
+  token: string | null;
+}): Headers => {
+  const resolved = new Headers(headers);
+
+  if (auth && token) {
+    resolved.set("authorization", `Bearer ${token}`);
+  }
+
+  return resolved;
+};
+
+const request = async (path: string, init: RequestJsonOptions = {}): Promise<Response> => {
+  const { auth = true, retryOnAuthFail = true, headers, ...rest } = init;
+
+  const doFetch = async (tokenForRequest: string | null) => {
+    return fetch(`${API_BASE_URL}${path}`, {
+      ...rest,
+      headers: buildHeaders({ headers, auth, token: tokenForRequest }),
+      credentials: "include"
+    });
+  };
+
+  let response = await doFetch(accessToken);
+
+  if (response.status === 401 && auth && retryOnAuthFail) {
+    const refreshedToken = await runRefreshTokenFlow();
+    if (refreshedToken) {
+      response = await doFetch(refreshedToken);
+    }
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    const payload = parseJsonSafely(text);
+
+    if (response.status === 401 && auth) {
+      unauthorizedHandler?.();
+    }
+
+    const message =
+      typeof payload === "object" && payload !== null && "message" in payload && typeof (payload as { message?: unknown }).message === "string"
+        ? (payload as { message: string }).message
+        : `请求失败(${response.status})`;
+
+    throw new ApiError(message, response.status, payload);
+  }
+
+  return response;
+};
+
+export async function requestJson<T>(path: string, init: RequestJsonOptions = {}): Promise<T> {
+  const response = await request(path, init);
+  const text = await response.text();
+  const payload = parseJsonSafely(text);
   return payload as T;
+}
+
+export async function requestRaw(path: string, init: RequestJsonOptions = {}): Promise<Response> {
+  return request(path, init);
 }

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -2,11 +2,7 @@ import { requestJson } from "./http";
 import type { EnrollmentProfileResponse } from "../types/profile";
 
 export const profileApi = {
-  getEnrollmentProfile(token: string) {
-    return requestJson<EnrollmentProfileResponse>("/auth/student/enrollment-profile", {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    });
+  getEnrollmentProfile() {
+    return requestJson<EnrollmentProfileResponse>("/auth/student/enrollment-profile");
   }
 };

--- a/src/services/report.ts
+++ b/src/services/report.ts
@@ -2,12 +2,9 @@ import { requestJson } from "./http";
 import type { GenerateReportsResponse } from "../types/report";
 
 export const reportApi = {
-  generate(token: string) {
+  generate() {
     return requestJson<GenerateReportsResponse>("/student/reports/generate", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
+      method: "POST"
     });
   }
 };

--- a/src/services/role-model.ts
+++ b/src/services/role-model.ts
@@ -2,11 +2,7 @@ import { requestJson } from "./http";
 import type { RoleModelDirection, RoleModelResponse } from "../types/role-model";
 
 export const roleModelApi = {
-  list(token: string, direction: RoleModelDirection) {
-    return requestJson<RoleModelResponse>(`/student/role-models/match?direction=${direction}`, {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    });
+  list(direction: RoleModelDirection) {
+    return requestJson<RoleModelResponse>(`/student/role-models/match?direction=${direction}`);
   }
 };

--- a/src/services/task.ts
+++ b/src/services/task.ts
@@ -1,47 +1,24 @@
-import { ApiError } from "./http";
+import { requestJson } from "./http";
 
-export async function uploadCertificate(token: string, file: File): Promise<{ fileId: string }> {
+export async function uploadCertificate(file: File): Promise<{ fileId: string }> {
   const formData = new FormData();
   formData.append("file", file);
 
-  const response = await fetch(`${(import.meta.env.VITE_API_BASE_URL as string | undefined)?.trim() || "http://localhost:3000"}/student/certificates/upload`, {
+  return requestJson<{ fileId: string }>("/student/certificates/upload", {
     method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`
-    },
     body: formData
   });
-
-  const text = await response.text();
-  const payload = text ? JSON.parse(text) : null;
-
-  if (!response.ok) {
-    throw new ApiError((payload as { message?: string } | null)?.message || "上传失败", response.status, payload);
-  }
-
-  return payload as { fileId: string };
 }
 
 export async function submitTaskCheckIn(
-  token: string,
   taskId: number,
   payload: { fileId: string; note: string }
 ): Promise<{ checkInId: number; status: string }> {
-  const response = await fetch(`${(import.meta.env.VITE_API_BASE_URL as string | undefined)?.trim() || "http://localhost:3000"}/student/tasks/${taskId}/check-ins`, {
+  return requestJson<{ checkInId: number; status: string }>(`/student/tasks/${taskId}/check-ins`, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`,
       "content-type": "application/json"
     },
     body: JSON.stringify(payload)
   });
-
-  const text = await response.text();
-  const data = text ? JSON.parse(text) : null;
-
-  if (!response.ok) {
-    throw new ApiError((data as { message?: string } | null)?.message || "打卡提交失败", response.status, data);
-  }
-
-  return data as { checkInId: number; status: string };
 }

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,79 +1,223 @@
 import { computed, reactive } from "vue";
+import { getPermissionsByRole } from "../constants/rbac";
 import { authApi } from "../services/auth";
-import type { FirstLoginVerifyPayload } from "../types/auth";
+import { configureAuthLifecycle, setAccessToken } from "../services/http";
+import type { AuthRole, AuthUser, FirstLoginVerifyPayload, SessionUser, UnifiedLoginResponse } from "../types/auth";
+
+interface PersistedAuthState {
+  firstLoginVerified: boolean;
+  verifiedUserId: string | null;
+}
 
 interface AuthState {
-  token: string | null;
-  mustChangePassword: boolean;
+  initialized: boolean;
+  initializing: boolean;
+  accessToken: string;
+  user: SessionUser | null;
   firstLoginVerified: boolean;
-  studentNo: string | null;
+  verifiedUserId: string | null;
 }
 
 const STORAGE_KEY = "lesi_stu_auth";
 
-const readInitialState = (): AuthState => {
+const readPersistedState = (): PersistedAuthState => {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) {
-    return { token: null, mustChangePassword: false, firstLoginVerified: false, studentNo: null };
+    return {
+      firstLoginVerified: false,
+      verifiedUserId: null
+    };
   }
 
   try {
-    const parsed = JSON.parse(raw) as AuthState;
+    const parsed = JSON.parse(raw) as PersistedAuthState;
     return {
-      token: parsed.token ?? null,
-      mustChangePassword: Boolean(parsed.mustChangePassword),
       firstLoginVerified: Boolean(parsed.firstLoginVerified),
-      studentNo: parsed.studentNo ?? null
+      verifiedUserId: parsed.verifiedUserId ?? null
     };
   } catch {
-    return { token: null, mustChangePassword: false, firstLoginVerified: false, studentNo: null };
+    return {
+      firstLoginVerified: false,
+      verifiedUserId: null
+    };
   }
 };
 
-const state = reactive<AuthState>(readInitialState());
+const persisted = readPersistedState();
+
+const state = reactive<AuthState>({
+  initialized: false,
+  initializing: false,
+  accessToken: "",
+  user: null,
+  firstLoginVerified: persisted.firstLoginVerified,
+  verifiedUserId: persisted.verifiedUserId
+});
 
 const persist = () => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      firstLoginVerified: state.firstLoginVerified,
+      verifiedUserId: state.verifiedUserId
+    } satisfies PersistedAuthState)
+  );
+};
+
+const toSessionUser = (user: AuthUser): SessionUser => ({
+  ...user,
+  permissions: getPermissionsByRole(user.role)
+});
+
+const applyAuthResult = (result: UnifiedLoginResponse) => {
+  const nextToken = result.accessToken.trim();
+  state.accessToken = nextToken;
+  setAccessToken(nextToken);
+
+  state.user = toSessionUser(result.user);
+
+  if (!state.user || state.verifiedUserId !== state.user.userId) {
+    state.firstLoginVerified = false;
+  }
+};
+
+const clearSession = () => {
+  state.accessToken = "";
+  state.user = null;
+  setAccessToken(null);
+};
+
+const fetchCurrentUserInternal = async (): Promise<SessionUser | null> => {
+  if (!state.accessToken) {
+    state.user = null;
+    return null;
+  }
+
+  const current = await authApi.me();
+  state.user = toSessionUser(current);
+
+  if (!state.user || state.verifiedUserId !== state.user.userId) {
+    state.firstLoginVerified = false;
+  }
+
+  return state.user;
+};
+
+const refreshSession = async (): Promise<string | null> => {
+  try {
+    const refreshed = await authApi.refresh();
+    applyAuthResult(refreshed);
+    persist();
+    return refreshed.accessToken;
+  } catch {
+    clearSession();
+    return null;
+  }
+};
+
+configureAuthLifecycle({
+  onRefreshAccessToken: refreshSession,
+  onUnauthorized: () => {
+    clearSession();
+  }
+});
+
+export const getDefaultRouteByRole = (role: AuthRole): string => {
+  if (role === "student") {
+    return state.firstLoginVerified ? "/reports" : "/first-verify";
+  }
+
+  return "/login";
 };
 
 export const useAuthStore = () => {
-  const isLoggedIn = computed(() => !!state.token);
+  const isLoggedIn = computed(() => !!state.user && !!state.accessToken);
   const requiresFirstVerify = computed(() => isLoggedIn.value && !state.firstLoginVerified);
 
-  const login = async (input: { studentNo: string; password: string }) => {
-    const result = await authApi.login(input);
-    state.token = result.token;
-    state.mustChangePassword = result.mustChangePassword;
-    state.firstLoginVerified = false;
-    state.studentNo = input.studentNo.trim();
+  const initialize = async () => {
+    if (state.initialized || state.initializing) {
+      return;
+    }
+
+    state.initializing = true;
+    try {
+      await refreshSession();
+      if (state.accessToken) {
+        await fetchCurrentUserInternal().catch(() => undefined);
+      }
+      persist();
+    } finally {
+      state.initializing = false;
+      state.initialized = true;
+    }
+  };
+
+  const loginByAccount = async (input: { account: string; password: string }) => {
+    const result = await authApi.login({
+      account: input.account.trim(),
+      password: input.password
+    });
+
+    applyAuthResult(result);
+
+    if (state.user?.role !== "student") {
+      clearSession();
+      throw new Error("请使用学生账号登录学生端");
+    }
+
     persist();
+    return state.user;
+  };
+
+  const fetchCurrentUser = async () => {
+    const user = await fetchCurrentUserInternal();
+    persist();
+    return user;
   };
 
   const firstLoginVerify = async (payload: FirstLoginVerifyPayload) => {
-    if (!state.token) {
+    if (!state.accessToken || !state.user) {
       throw new Error("未登录");
     }
 
-    const result = await authApi.firstLoginVerify(state.token, payload);
+    const result = await authApi.firstLoginVerify(payload);
     state.firstLoginVerified = result.verified;
+    state.verifiedUserId = result.verified ? state.user.userId : null;
     persist();
     return result;
   };
 
-  const logout = () => {
-    state.token = null;
-    state.studentNo = null;
-    state.firstLoginVerified = false;
-    state.mustChangePassword = false;
-    persist();
+  const logout = async () => {
+    try {
+      await authApi.logout();
+    } finally {
+      clearSession();
+      state.initialized = true;
+    }
+  };
+
+  const hasRole = (roles: AuthRole[]) => {
+    return Boolean(state.user && roles.includes(state.user.role));
+  };
+
+  const hasPermissions = (permissions: string[]) => {
+    if (!state.user) {
+      return false;
+    }
+
+    return permissions.every((permission) => state.user!.permissions.includes(permission));
   };
 
   return {
     state,
     isLoggedIn,
     requiresFirstVerify,
-    login,
+    initialize,
+    loginByAccount,
+    fetchCurrentUser,
     firstLoginVerify,
-    logout
+    logout,
+    hasRole,
+    hasPermissions
   };
 };

--- a/src/stores/report.ts
+++ b/src/stores/report.ts
@@ -4,37 +4,55 @@ import type { ReportDirection } from "../types/report";
 
 interface ReportState {
   loaded: boolean;
+  loadedUserId: string | null;
   jobId: number | null;
   status: string | null;
   reports: Record<ReportDirection, string>;
 }
 
+const initialReports = (): Record<ReportDirection, string> => ({
+  employment: "",
+  postgraduate: "",
+  civil_service: ""
+});
+
 const state = reactive<ReportState>({
   loaded: false,
+  loadedUserId: null,
   jobId: null,
   status: null,
-  reports: {
-    employment: "",
-    postgraduate: "",
-    civil_service: ""
-  }
+  reports: initialReports()
 });
 
 export const useReportStore = () => {
-  const ensureLoaded = async (token: string) => {
-    if (state.loaded) {
+  const ensureLoaded = async (userId: string) => {
+    if (!userId) {
+      throw new Error("未登录");
+    }
+
+    if (state.loaded && state.loadedUserId === userId) {
       return;
     }
 
-    const result = await reportApi.generate(token);
+    const result = await reportApi.generate();
     state.reports = result.reports;
     state.jobId = result.jobId;
     state.status = result.status;
     state.loaded = true;
+    state.loadedUserId = userId;
+  };
+
+  const reset = () => {
+    state.loaded = false;
+    state.loadedUserId = null;
+    state.jobId = null;
+    state.status = null;
+    state.reports = initialReports();
   };
 
   return {
     state,
-    ensureLoaded
+    ensureLoaded,
+    reset
   };
 };

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,8 +1,32 @@
-export interface StudentLoginResponse {
-  token: string;
-  tokenType: string;
+export type AuthRole = "student" | "teacher" | "admin";
+
+export interface AuthScope {
+  schoolId?: number;
+  collegeId?: number;
+  majorId?: number;
+  classId?: number;
+}
+
+export interface AuthUser {
+  userId: string;
+  role: AuthRole;
+  account: string;
+  displayName: string;
+  studentId?: number;
+  studentNo?: string;
+  teacherId?: string;
+  mustChangePassword?: boolean;
+  scope?: AuthScope;
+}
+
+export interface SessionUser extends AuthUser {
+  permissions: string[];
+}
+
+export interface UnifiedLoginResponse {
+  accessToken: string;
   expiresIn: number;
-  mustChangePassword: boolean;
+  user: AuthUser;
 }
 
 export interface FirstLoginVerifyPayload {


### PR DESCRIPTION
## 背景
- 对齐父任务：Typeve/lesi-edu-platform#69
- 对齐子任务：#14

## 本次改造
- 登录切换为统一接口 `POST /auth/login`
- 会话刷新/登出/当前用户接入：`/auth/refresh`、`/auth/logout`、`/auth/me`
- HTTP 层统一 Bearer 注入，401 自动 refresh 并重试
- 学生端业务 API 移除 token 透传参数，统一走会话链路
- 保留首登校验流程，身份来源切换为统一 auth store
- 路由守卫补齐（requiresAuth + requiresVerified + role/permission）

## 影响范围
- `src/services/http.ts`、`src/services/auth.ts`
- `src/stores/auth.ts`、`src/stores/report.ts`
- `src/router/index.ts`
- `src/pages/*`（登录、测评、画像、报告、任务、榜样）

## 验证
- [x] `pnpm check`
- [x] `pnpm build`

Closes #14
