### PR TITLE
fix: 修复STU测评题目无序号问题

### DIFF
--- a/src/pages/AssessmentQuestionsPage.vue
+++ b/src/pages/AssessmentQuestionsPage.vue
@@ -82,8 +82,8 @@ const onSubmit = async () => {
     <p v-else-if="errorText && !questions.length" class="state-error mt-6">{{ errorText }}</p>
 
     <form v-else class="mt-6 space-y-4" @submit.prevent="onSubmit">
-      <article v-for="question in questions" :key="question.questionId" class="surface-soft p-4">
-        <p class="text-sm font-medium leading-6 text-slate-900">{{ question.order }}. {{ question.text }}</p>
+      <article v-for="(question, index) in questions" :key="question.questionId" class="surface-soft p-4">
+        <p class="text-sm font-medium leading-6 text-slate-900">{{ index + 1 }}. {{ question.text }}</p>
 
         <div class="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-5">
           <button


### PR DESCRIPTION
Closes #20

## 变更
- 测评题目列表改为使用前端索引展示序号：`index + 1`。
- 保证题目始终按列表顺序显示连续编号（1~50）。

## 说明
- 不再依赖后端 `order` 字段显示序号，避免缺失/异常导致无序号问题。
- 不影响题目提交 payload（仍按 `questionId + score` 提交）。

## 验证
- `pnpm check` ✅
- `pnpm build` ✅
